### PR TITLE
Fix missing include for stat

### DIFF
--- a/myCustomWindow.cpp
+++ b/myCustomWindow.cpp
@@ -2,6 +2,7 @@
 // Created by gduval on 15/04/2022.
 //
 #include <iostream>
+#include <sys/stat.h>
 #include "myCustomWindow.h"
 
 using namespace std;


### PR DESCRIPTION
## Summary
- include `<sys/stat.h>` in `myCustomWindow.cpp`

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: gtkmm headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6852b40319c48327bb3a7eb4cb71df8b